### PR TITLE
[xwalk-2152] Fix sandbox security

### DIFF
--- a/samples/Sandbox/index.html
+++ b/samples/Sandbox/index.html
@@ -52,7 +52,7 @@ Authors:
     </li>
     <li>
       <p>There are an input form with text "Filler Text" and a button "Submit" in the frame below, and there is green text "Filler Text" after click the button.</p>
-      <iframe src="res/sandbox-allow-forms.html" sandbox="allow-forms" height="100" width="220"></iframe>
+      <iframe src="res/sandbox-allow-forms.html" sandbox="allow-same-origin allow-forms" height="100" width="220"></iframe>
     </li>
     <li>
       <p>There is text "Filler Text" below.</p>

--- a/samples/Sandbox/res/sandbox-allow-forms.html
+++ b/samples/Sandbox/res/sandbox-allow-forms.html
@@ -34,7 +34,7 @@ Authors:
 <title>Support file of sandbox allow-forms</title>
 
 <form action="sandbox-allow-same-origin.html">
-  <input type="text" value="Filler Text">
+  <input type="text" value="Filler Text" readonly>
   <input type="submit" value="Submit">
 </form>
 

--- a/samples/Sandbox/res/sandbox-allow-scripts.html
+++ b/samples/Sandbox/res/sandbox-allow-scripts.html
@@ -32,11 +32,17 @@ Authors:
 
 <meta charset="utf-8">
 <title>Support file of sandbox allow-scripts</title>
+<style>
+  #testDiv {
+    background: red;
+    height: 100px;
+    width: 100px;
+  }
+</style>
 
-<img src="../../../res/images/red-100x100.png"
-     alt="User agent does not support .png image">
+<div id="testDiv"></div>
 
 <script>
-  document.querySelector("img").src = "../../../res/images/green-100x100.png";
+  document.getElementById("testDiv").style.backgroundColor = "green";
 </script>
 


### PR DESCRIPTION
- Use colored div element instead of image element
- Add 'allow-same-origin' in allow-forms tests

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: [Android]
Unit test result summary: pass 1, fail 0, block 0
