### PR TITLE
[xwalk-2511] Update ScreenOrientation in FullScreen mode

### DIFF
--- a/samples/ScreenOrientation/index.html
+++ b/samples/ScreenOrientation/index.html
@@ -46,18 +46,19 @@ Authors:
 </div>
 
 <div class="content">
-  <h4>This sample demonstrates screen orientation lock/unlock methods.</h4>
+  <h4>This sample demonstrates screen orientation lock/unlock methods in fullscreen mode.</h4>
 
   <div id="d">
     <img src="../../res/images/ryb-100x100.png" width="100%" height="100%">
   </div>
 
   <div>
+    <button id="start" class="btn btn-default btn-lg btn-block">FullScreen</button>
+    <button id="cancel" class="btn btn-default btn-lg btn-block" style="display: none;">Cancel FullScreen</button>
     <button id="b1" class="btn btn-default btn-lg btn-block">Lock to protrait primary</button>
     <button id="b2" class="btn btn-default btn-lg btn-block">Lock to protrait secondary</button>
     <button id="b3" class="btn btn-default btn-lg btn-block">Lock to landscape primary</button>
     <button id="b4" class="btn btn-default btn-lg btn-block">Lock to landscape secondary</button>
-    <button id="b5" class="btn btn-default btn-lg btn-block">Unlock (view same as protrait primary)</button>
   </div>
 </div>
 

--- a/samples/ScreenOrientation/js/main.js
+++ b/samples/ScreenOrientation/js/main.js
@@ -30,6 +30,7 @@ Authors:
 */
 
 $(document).ready( function() {
+
   $("#b1").click( function() {
     screen.orientation.lock("portrait-primary");
   });
@@ -42,11 +43,25 @@ $(document).ready( function() {
   $("#b4").click( function() {
     screen.orientation.lock("landscape-secondary");
   });
-  $("#b5").click( function() {
-    screen.orientation.unlock();
-  });
-});
 
-$(window).unload( function() {
-  screen.orientation.unlock();
+  document.getElementById("start").onclick = function() {
+    document.onwebkitfullscreenchange = function() {
+      //https://w3c.github.io/screen-orientation/#locking-the-screen-orientation
+      //a user agent might require a document's top-level browsing context to be fullscreen (see Interaction with FullScreen API) in order to allow an orientation lock.
+      screen.orientation.unlock();
+      document.getElementById("start").style.display = "none";
+      document.getElementById("cancel").style.display = "";
+    }
+    document.documentElement.webkitRequestFullScreen();
+  }
+
+  document.getElementById("cancel").onclick = function() {
+    document.onwebkitfullscreenchange = function() {
+      document.getElementById("start").style.display = "";
+      document.getElementById("cancel").style.display = "none";
+    }
+    screen.orientation.unlock();
+    document.webkitCancelFullScreen();
+  }
+
 });


### PR DESCRIPTION
- https://w3c.github.io/screen-orientation/#locking-the-screen-orientation

  a user agent might require a document's top-level browsing context to be fullscreen (see Interaction with FullScreen API) in order to allow an orientation lock.

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: [Android][Crosswalk 14.42.335.0]
Unit test result summary: pass 1, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-4215