### PR TITLE
[demo-express] Add config for ManifestDemo to support pack with longer version length

### DIFF
--- a/suite.json
+++ b/suite.json
@@ -62,12 +62,14 @@
                 "samples-wrt/ManifestDemo3/res": {
                     "apk-icon-opt": "",
                     "app-name": "manifestdemo3",
+                    "apk-version-opt":"1.0.0.1",
                     "apk-type":"MANIFEST",
                     "install-path": "."
                 },
                 "samples-wrt/ManifestDemo4/res": {
                     "apk-icon-opt": "",
                     "app-name": "manifestdemo4",
+                    "apk-version-opt":"1.0.0.0.1",
                     "apk-type":"MANIFEST",
                     "install-path": "."
                 },
@@ -89,7 +91,6 @@
                 "*"
             ], 
             "copylist": {
-                "demo-ex-em.png": "samples-embedding/res/drawable-hdpi/icon.png",
                 "inst.em.py": "inst.py", 
                 "tests.embedding.xml": "tests.xml"
             }, 
@@ -97,7 +98,10 @@
                 "samples-embedding": {
                     "app-name": "embeddingapi", 
                     "app-type": "EMBEDDINGAPI", 
-                    "embeddingapi-library-name": "crosswalk-webview"
+                    "embeddingapi-library-name": "crosswalk-webview",
+                    "copylist": {
+                        "../demo-ex-em.png": "res/drawable-hdpi/icon.png"
+                    }
                 }
             }
         },


### PR DESCRIPTION
- Add apk-version-opt attribute in suite.json for ManifestDemo3 and ManifestDemo4
- Use demo-ex-em.png of demo-express as the icon of demoexpress embiddingapi

BUG=https://crosswalk-project.org/jira/browse/XWALK-4296