### PR TITLE
[demo-express] Use extractLane function instead of SIMD.XXXX.x/y/z/w

### DIFF
--- a/samples/SIMD/res/mandelbrot.js
+++ b/samples/SIMD/res/mandelbrot.js
@@ -165,10 +165,10 @@ function drawMandelbrot (width, height, xc, yc, scale, use_simd) {
         var xf4 = SIMD.Float32x4(xf, xf, xf, xf);
         var yf4 = SIMD.Float32x4(yf, yf+yd, yf+yd+yd, yf+yd+yd+yd);
         var m4   = mandelx4 (xf4, yf4);
-        canvas.mapColorAndSetPixel (x, y,   m4.x);
-        canvas.mapColorAndSetPixel (x, y+1, m4.y);
-        canvas.mapColorAndSetPixel (x, y+2, m4.z);
-        canvas.mapColorAndSetPixel (x, y+3, m4.w);
+        canvas.mapColorAndSetPixel (x, y,   SIMD.Int32x4.extractLane(m4, 0));
+        canvas.mapColorAndSetPixel (x, y+1, SIMD.Int32x4.extractLane(m4, 1));
+        canvas.mapColorAndSetPixel (x, y+2, SIMD.Int32x4.extractLane(m4, 2));
+        canvas.mapColorAndSetPixel (x, y+3, SIMD.Int32x4.extractLane(m4, 3));
         yf += ydx4;
       }
     }


### PR DESCRIPTION
Impacted TCs num(approved): New 0, Update 1, Delete 0
Unit test Platform: Crosswalk Project for Android 17.45.437.0
Unit test result summary: Pass 1, Fail 0, Blocked 0

https://crosswalk-project.org/jira/browse/XWALK-5731