### PR TITLE
[wrt] Update tests for apptools replace make_apk.py to build test app

### DIFF
--- a/samples-wrt/ManifestCSP/res/manifest.json
+++ b/samples-wrt/ManifestCSP/res/manifest.json
@@ -1,5 +1,6 @@
 {
   "csp": "default-src 'unsafe-inline';connect-src http://w3school.com.cn;style-src 'unsafe-inline';img-src 'self';media-src *;frame-src http://w3school.com.cn;font-src 'self';script-src 'self' 'unsafe-inline'",
   "name": "manifest_csp_tests",
-  "start_url": "index.html"
+  "start_url": "index.html",
+  "xwalk_package_id": "org.xwalk.manifestcsptest"
 }

--- a/samples-wrt/ManifestDemo1/res/manifest.json
+++ b/samples-wrt/ManifestDemo1/res/manifest.json
@@ -20,5 +20,6 @@
     },
     "ready_when": "complete"
   },
-  "xwalk_version": "1.0"
+  "xwalk_package_id": "org.xwalk.manifestdemo1",
+  "xwalk_app_version": "1.0"
 }

--- a/samples-wrt/ManifestDemo2/res/manifest.json
+++ b/samples-wrt/ManifestDemo2/res/manifest.json
@@ -20,5 +20,6 @@
     },
     "ready_when": "user-interactive"
   },
-  "xwalk_version": "1.0.1"
+  "xwalk_package_id": "org.xwalk.manifestdemo2",
+  "xwalk_app_version": "1.0.1"
 }

--- a/samples-wrt/ManifestDemo3/index.html
+++ b/samples-wrt/ManifestDemo3/index.html
@@ -44,13 +44,12 @@ Authors:
 </div>
 <div class="content">
   <h4>Crosswalk Manifest Demo 3</h4>
-  <p>This sample demonstrates mainfest members "icons", "xwalk_version", "orientation", "display" and "xwalk_launch_screen"</p>
+  <p>This sample demonstrates mainfest members "icons", "orientation", "display" and "xwalk_launch_screen"</p>
   <p>This demo shows App features can be configured by manifest.json</p>
   <p>Download app named like "manifestdemo3.apk" from <a href="https://github.com/crosswalk-project/demo-express/releases">https://github.com/crosswalk-project/demo-express/releases</a> (It might be included in .zip files in this page)</p>
   <p>Check below features after install the app</p>
   <ul>
     <li>Icon: A bmp format icon (turquoise background) with "Manifest BMP" text</li>
-    <li>Xwalk_version: the value like 1.0.0.120150101</li>
   </ul>
   <p>Check below features after launch the app</p>
   <ul>

--- a/samples-wrt/ManifestDemo3/res/index.html
+++ b/samples-wrt/ManifestDemo3/res/index.html
@@ -38,7 +38,6 @@ Authors:
   This demo shows following features can be configured by manifest.json:
   <ul>
     <li>Icon: A bmp format icon (turquoise background color)</li>
-    <li>Xwalk_version: 1.0.0.1</li>
     <li>Orientation: Landscape mode</li>
     <li>Splash Screen: Turquoise background color</li>
     <li>Splash Screen: The first visually non-empty paint has occurred</li>

--- a/samples-wrt/ManifestDemo3/res/manifest.json
+++ b/samples-wrt/ManifestDemo3/res/manifest.json
@@ -17,5 +17,5 @@
     },
     "ready_when": "custom"
   },
-  "xwalk_version": "1.0.0.1"
+  "xwalk_package_id": "org.xwalk.manifestdemo3"
 }

--- a/samples-wrt/ManifestDemo4/index.html
+++ b/samples-wrt/ManifestDemo4/index.html
@@ -44,13 +44,12 @@ Authors:
 </div>
 <div class="content">
   <h4>Crosswalk Manifest Demo 4</h4>
-  <p>This sample demonstrates mainfest members "icons", "xwalk_version", "orientation", "display" and "xwalk_launch_screen"</p>
+  <p>This sample demonstrates mainfest members "icons", "orientation", "display" and "xwalk_launch_screen"</p>
   <p>This demo shows App features can be configured by manifest.json</p>
   <p>Download app named like "manifestdemo4.apk" from <a href="https://github.com/crosswalk-project/demo-express/releases">https://github.com/crosswalk-project/demo-express/releases</a> (It might be included in .zip files in this page)</p>
   <p>Check below features after install the app</p>
   <ul>
     <li>Icon: A jpg format icon (purple background) with "Manifest JPG" text</li>
-    <li>Xwalk_version: the value like 1.0.0.0.120150101</li>
   </ul>
   <p>Check below features after launch the app</p>
   <ul>
@@ -66,7 +65,7 @@ Authors:
 </div>
 <div class="modal fade" id="popup_info">
   <ul>
-    <li>Test values include: jpg format icons, five digits version, landscape orientation, minimal-ui display, first-paint ready_when and landscape</li>
+    <li>Test values include: jpg format icons, landscape orientation, minimal-ui display, first-paint ready_when and landscape</li>
     <li>Minimal-ui: This mode is similar to fullscreen, but provides the end-user with some means to access a minimal set of UI elements for controlling navigation (i.e., back, forward, reload, and perhaps some way of viewing the document's address)</li>
     <li>Xwalk_launch_screen members
       <ul>

--- a/samples-wrt/ManifestDemo4/res/index.html
+++ b/samples-wrt/ManifestDemo4/res/index.html
@@ -38,7 +38,6 @@ Authors:
   This demo shows following features can be configured by manifest.json:
   <ul>
     <li>Icon: A jpg format icon (purple background color)</li>
-    <li>Xwalk_version: 1.0.0.0.1</li>
     <li>Orientation: Landscape mode</li>
     <li>Splash Screen: Purple background color</li>
     <li>Splash Screen: Landscape mode</li>

--- a/samples-wrt/ManifestDemo4/res/manifest.json
+++ b/samples-wrt/ManifestDemo4/res/manifest.json
@@ -20,5 +20,5 @@
     },
     "ready_when": "first-paint"
   },
-  "xwalk_version": "1.0.0.0.1"
+  "xwalk_package_id": "org.xwalk.manifestdemo4"
 }

--- a/samples-wrt/ManifestDemo5/res/manifest.json
+++ b/samples-wrt/ManifestDemo5/res/manifest.json
@@ -15,5 +15,6 @@
       "image_border": "1px 1px round"
     },
     "ready_when": "complete"
-  }
+  },
+  "xwalk_package_id": "org.xwalk.manifestdemo5"
 }

--- a/samples-wrt/ManifestDemo6/res/manifest.json
+++ b/samples-wrt/ManifestDemo6/res/manifest.json
@@ -15,5 +15,6 @@
       "image_border": "1px repeat round"
     },
     "ready_when": "custom"
-  }
+  },
+  "xwalk_package_id": "org.xwalk.manifestdemo6"
 }

--- a/samples-wrt/ManifestDemo7/res/manifest.json
+++ b/samples-wrt/ManifestDemo7/res/manifest.json
@@ -1,6 +1,7 @@
 {
   "name": "manifest_demo_7",
   "start_url": "index.html",
+  "xwalk_package_id": "org.xwalk.manifestdemo7",
   "xwalk_view": {
     "background_color": "#ff01abcd"
   }

--- a/samples-wrt/ManifestDemo8/res/manifest.json
+++ b/samples-wrt/ManifestDemo8/res/manifest.json
@@ -7,6 +7,7 @@
       "background_color": "#01abcd"
     }
   },
+  "xwalk_package_id": "org.xwalk.manifestdemo8",
   "xwalk_view": {
       "background_color": "#ff01abcd"
   }

--- a/samples-wrt/ManifestDemo9/res/manifest.json
+++ b/samples-wrt/ManifestDemo9/res/manifest.json
@@ -13,5 +13,6 @@
       "image": "loading-auto.png"
     },
     "ready_when": "custom"
-  }
+  },
+  "xwalk_package_id": "org.xwalk.manifestdemo9"
 }

--- a/samples-wrt/SchemeContent/res/manifest.json
+++ b/samples-wrt/SchemeContent/res/manifest.json
@@ -1,4 +1,5 @@
 {
   "name": "schemecontent",
-  "start_url": "index.html"
+  "start_url": "index.html",
+  "xwalk_package_id":"org.xwalk.schemecontent"
 }

--- a/samples-wrt/SchemesCheck/res/manifest.json
+++ b/samples-wrt/SchemesCheck/res/manifest.json
@@ -7,5 +7,6 @@
   ],
   "name": "testapp_scheme",
   "start_url": "index.html",
-  "xwalk_version": "1.0.0"
+  "xwalk_package_id": "org.xwalk.schemescheck",
+  "xwalk_app_version": "1.0.0"
 }


### PR DESCRIPTION
- Fail BUG/Feature ID: XWALK-5812

- Block Analyse: the apptools doesn't implement the field xwalk_launch_screen in manifest.json

Impacted TCs num(approved): New 0, Update 15, Delete 0
Unit test Platform: Android Crosswalk Canary 17.45.437.0
Android test result summary: Pass 3, Fail 1, Block 9