### PR TITLE
Add READ_EXTERNAL_STORAGE permission

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,8 @@
     "MODIFY_AUDIO_SETTINGS",
     "RECORD_AUDIO",
     "ACCESS_FINE_LOCATION",
-    "VIBRATE"
+    "VIBRATE",
+    "READ_EXTERNAL_STORAGE"
   ],
   "icons": [
     {


### PR DESCRIPTION
Camera, FileReader also need this permission for external storage.
This permission is added default in make_apk.py before.

Impacted tests(approved): new 0, update 2, delete 0
Unit test platform: Crosswalk Project for Android 19.48.497.0
Unit test result summary: pass 2, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-6032