### PR TITLE
Add WRITE_EXTERNAL_STORAGE permission for Camera

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,8 @@
     "RECORD_AUDIO",
     "ACCESS_FINE_LOCATION",
     "VIBRATE",
-    "READ_EXTERNAL_STORAGE"
+    "READ_EXTERNAL_STORAGE",
+    "WRITE_EXTERNAL_STORAGE"
   ],
   "icons": [
     {


### PR DESCRIPTION
Camera need save iamge to external storage, add this permission for it.

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: Crosswalk Project for Android 19.48.497.0
Unit test result summary: pass 1, fail 0, block 0